### PR TITLE
Move Disk usage indicator from Workbench View to Iframe's button container

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,7 +35,7 @@ Makefile                                  @pcrespov @sanderegg
 /services/payments/                       @pcrespov
 /services/resource-usage-tracker/         @matusdrobuliak66
 /services/static-webserver/               @GitHK
-/services/static-webserver/client/        @jsaq007 @ignapas
+/services/static-webserver/client/        @jsaq007 @ignapas @odeimaiz
 /services/storage/                        @sanderegg
 /services/web/server/                     @pcrespov @sanderegg @GitHK @matusdrobuliak66
 /tests/e2e-playwright/                    @matusdrobuliak66

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -541,10 +541,13 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
         osparc.utils.Utils.setIdToWidget(list, "studiesList");
       }
 
+      /*
+      // Import is disabled until an Export function is implemented
       const importStudyButton = this.__createImportButton();
       const isDisabled = osparc.utils.DisabledPlugins.isImportDisabled();
       importStudyButton.setVisibility(isDisabled ? "excluded" : "visible");
       this._toolbar.add(importStudyButton);
+      */
 
       const selectStudiesButton = this.__createSelectButton();
       this._toolbar.add(selectStudiesButton);
@@ -573,7 +576,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
             card.setEnabled(!multiEnabled);
           }
         });
-        importStudyButton.setEnabled(!multiEnabled);
+        // importStudyButton.setEnabled(!multiEnabled);
       });
 
       this._resourcesContainer.addListener("changeSelection", e => {

--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -1102,6 +1102,7 @@ qx.Class.define("osparc.data.model.Node", {
         iframe.setShowToolbar(false);
       }
       iframe.addListener("restart", () => this.__restartIFrame(), this);
+      iframe.getDiskUsageIndicator().setCurrentNode(this)
       this.setIFrame(iframe);
     },
 

--- a/services/static-webserver/client/source/class/osparc/share/CollaboratorsStudy.js
+++ b/services/static-webserver/client/source/class/osparc/share/CollaboratorsStudy.js
@@ -202,7 +202,7 @@ qx.Class.define("osparc.share.CollaboratorsStudy", {
       Promise.all(promises)
         .then(values => {
           const noAccessible = values.filter(value => value["accessible"] === false);
-          if (noAccessible.length) {
+          if (noAccessible.length && !osparc.product.Utils.isS4LProduct()) {
             const shareePermissions = new osparc.share.ShareePermissions(noAccessible);
             const win = osparc.ui.window.Window.popUpInWindow(shareePermissions, this.tr("Sharee permissions"), 500, 500, "@FontAwesome5Solid/exclamation-triangle/14").set({
               clickAwayClose: false,

--- a/services/static-webserver/client/source/class/osparc/widget/PersistentIframe.js
+++ b/services/static-webserver/client/source/class/osparc/widget/PersistentIframe.js
@@ -135,9 +135,9 @@ qx.Class.define("osparc.widget.PersistentIframe", {
         alignY: "middle"
       }));
 
-      const diskUsageIndicator = this.__diskUsageIndicator = new osparc.workbench.DiskUsageIndicator().set({
-        margin: 0,
-        padding: 0
+      const diskUsageIndicator = this.__diskUsageIndicator = new osparc.workbench.DiskUsageIndicator();
+      diskUsageIndicator.getChildControl("disk-indicator").set({
+        margin: 0
       });
       buttonContainer.add(diskUsageIndicator);
 

--- a/services/static-webserver/client/source/class/osparc/widget/PersistentIframe.js
+++ b/services/static-webserver/client/source/class/osparc/widget/PersistentIframe.js
@@ -105,6 +105,7 @@ qx.Class.define("osparc.widget.PersistentIframe", {
     __iframe: null,
     __syncScheduled: null,
     __buttonContainer: null,
+    __diskUsageIndicator: null,
     __reloadButton: null,
     __zoomButton: null,
 
@@ -128,10 +129,17 @@ qx.Class.define("osparc.widget.PersistentIframe", {
       });
       const iframeEl = this._getIframeElement();
       iframeEl.setAttribute("allow", "clipboard-write");
+
       const buttonContainer = this.__buttonContainer = new qx.ui.container.Composite(new qx.ui.layout.HBox(10).set({
         alignX: "right",
         alignY: "middle"
       }));
+
+      const diskUsageIndicator = this.__diskUsageIndicator = new osparc.workbench.DiskUsageIndicator().set({
+        margin: 0,
+        padding: 0
+      });
+      buttonContainer.add(diskUsageIndicator);
 
       const reloadButton = this.__reloadButton = this.self().createToolbarButton().set({
         label: this.tr("Reload"),
@@ -144,6 +152,7 @@ qx.Class.define("osparc.widget.PersistentIframe", {
       }, this);
       osparc.utils.Utils.setIdToWidget(reloadButton, "iFrameRestartBtn");
       buttonContainer.add(reloadButton);
+
       const zoomButton = this.__zoomButton = this.self().createToolbarButton().set({
         label: this.self().getZoomLabel(false),
         icon: this.self().getZoomIcon(false)
@@ -153,6 +162,7 @@ qx.Class.define("osparc.widget.PersistentIframe", {
         this.maximizeIFrame(!this.hasState("maximized"));
       }, this);
       buttonContainer.add(zoomButton);
+
       appRoot.add(buttonContainer, {
         top: this.self().HIDDEN_TOP
       });
@@ -186,6 +196,10 @@ qx.Class.define("osparc.widget.PersistentIframe", {
         }
       });
       return standin;
+    },
+
+    getDiskUsageIndicator: function() {
+      return this.__diskUsageIndicator;
     },
 
     maximizeIFrame: function(maximize) {
@@ -228,10 +242,10 @@ qx.Class.define("osparc.widget.PersistentIframe", {
           height: divSize.height - this.getToolbarHeight()
         });
 
-        const rightOffest = this.hasState("maximized") ? 0 : 0;
+        const rightOffset = this.hasState("maximized") ? 0 : 0;
         this.__buttonContainer.setLayoutProperties({
           top: (divPos.top - iframeParentPos.top),
-          right: (iframeParentPos.right - iframeParentPos.left - divPos.right) + rightOffest
+          right: (iframeParentPos.right - iframeParentPos.left - divPos.right) + rightOffset
         });
 
         this.__buttonContainer.setVisibility(this.isShowToolbar() ? "visible" : "excluded");

--- a/services/static-webserver/client/source/class/osparc/workbench/DiskUsageController.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/DiskUsageController.js
@@ -109,6 +109,9 @@ qx.Class.define("osparc.workbench.DiskUsageController", {
 
       const store = osparc.store.Store.getInstance();
       const currentStudy = store.getCurrentStudy();
+      if (!currentStudy) {
+        return;
+      }
       const node = currentStudy.getWorkbench().getNode(id);
 
       const nodeName = node ? node.getLabel() : null;

--- a/services/static-webserver/client/source/class/osparc/workbench/DiskUsageController.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/DiskUsageController.js
@@ -53,18 +53,15 @@ qx.Class.define("osparc.workbench.DiskUsageController", {
     __prevDiskUsageStateList: null,
     __diskUsage: null,
 
-    subscribe: function(nodeId, callback, node) {
+    subscribe: function(nodeId, callback) {
       if (this.__callbacks[nodeId]) {
-        console.log("new subscribe to node", node.getNodeId() === nodeId, node.getLabel(), this.__callbacks[nodeId]);
         this.__callbacks[nodeId].push(callback);
       } else {
-        console.log("Listen to node", node.getNodeId() === nodeId, node.getLabel(), this.__callbacks[nodeId] = [callback]);
         this.__callbacks[nodeId] = [callback];
       }
     },
 
-    unsubscribe: function(nodeId, callback, node) {
-      console.log("unsubscribe to node", nodeId, node.getLabel());
+    unsubscribe: function(nodeId, callback) {
       if (this.__callbacks[nodeId]) {
         this.__callbacks[nodeId] = this.__callbacks[nodeId].filter(cb => cb !== callback)
       }
@@ -113,7 +110,7 @@ qx.Class.define("osparc.workbench.DiskUsageController", {
 
       const store = osparc.store.Store.getInstance();
       const currentStudy = store.getCurrentStudy();
-      const node = currentStudy.getNode(id);
+      const node = currentStudy.getWorkbench().getNode(id);
 
       const nodeName = node ? node.getLabel() : null;
       if (nodeName === null) {

--- a/services/static-webserver/client/source/class/osparc/workbench/DiskUsageIndicator.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/DiskUsageIndicator.js
@@ -29,22 +29,14 @@ qx.Class.define("osparc.workbench.DiskUsageIndicator", {
     const lowDiskSpacePreferencesSettings = osparc.Preferences.getInstance();
     this.__lowDiskThreshold = lowDiskSpacePreferencesSettings.getLowDiskSpaceThreshold();
     this.__lastDiskUsage = {};
-    const layout = this.__layout = new qx.ui.layout.VBox(2);
 
-    this._setLayout(layout);
+    this._setLayout(new qx.ui.layout.VBox());
 
     // Subscribe to disk space threshold - Default 5GB
     lowDiskSpacePreferencesSettings.addListener("changeLowDiskSpaceThreshold", e => {
       this.__lowDiskThreshold = e.getData();
       this.__updateDiskIndicator();
     }, this);
-
-    /*
-    // Subscribe to node selected node
-    this.addListener("changeSelectedNode", e => this.__applySelectedNode(e.getData()), this);
-    // Subscribe to nodes in the workbench
-    this.addListener("changeCurrentNode", e => this.__applyCurrentNode(e.getData()), this);
-    */
   },
 
   properties: {
@@ -54,20 +46,10 @@ qx.Class.define("osparc.workbench.DiskUsageIndicator", {
       nullable: true,
       event: "changeCurrentNode",
       apply: "__applyCurrentNode",
-    },
-
-    selectedNode: {
-      check: "osparc.data.model.Node",
-      init: null,
-      nullable: true,
-      event: "changeSelectedNode",
-      apply: "__applySelectedNode",
     }
   },
 
   members: {
-    __indicator: null,
-    __label: null,
     __lowDiskThreshold: null,
     __lastDiskUsage: null,
 
@@ -89,8 +71,7 @@ qx.Class.define("osparc.workbench.DiskUsageIndicator", {
             allowShrinkY: false,
             allowGrowX: true,
             allowGrowY: false,
-            toolTipText: this.tr("Disk usage"),
-            // visibility: "excluded"
+            toolTipText: this.tr("Disk usage")
           });
           this._add(control)
           break;
@@ -113,17 +94,6 @@ qx.Class.define("osparc.workbench.DiskUsageIndicator", {
     },
 
     __applyCurrentNode: function(node, prevNode) {
-      // Unsubscribe from previous node's disk usage data
-      if (prevNode) {
-        this._unsubscribe(prevNode.getNodeId())
-      }
-
-      // Subscribe to disk usage data for the new node
-      this._subscribe(node);
-    },
-
-
-    __applySelectedNode: function(node, prevNode) {
       // Unsubscribe from previous node's disk usage data
       if (prevNode) {
         this._unsubscribe(prevNode.getNodeId())
@@ -166,18 +136,18 @@ qx.Class.define("osparc.workbench.DiskUsageIndicator", {
 
       const indicator = this.getChildControl("disk-indicator");
 
-      const selectedNode = this.getSelectedNode() || this.getCurrentNode();
-      if (selectedNode) {
+      const currentNode = this.getCurrentNode();
+      if (currentNode) {
         indicator.setVisibility("visible");
       } else {
         indicator.setVisibility("exclude");
         return;
       }
 
-      const selectedNodeId = selectedNode.getNodeId();
+      const currentNodeId = currentNode.getNodeId();
 
-      if (!diskUsage && (selectedNodeId in this.__lastDiskUsage)) {
-        diskUsage = this.__lastDiskUsage[selectedNodeId];
+      if (!diskUsage && (currentNodeId in this.__lastDiskUsage)) {
+        diskUsage = this.__lastDiskUsage[currentNodeId];
       }
       if (!diskUsage) {
         return;
@@ -197,18 +167,14 @@ qx.Class.define("osparc.workbench.DiskUsageIndicator", {
 
       const indicatorLabel = this.getChildControl("disk-indicator-label");
       // indicatorLabel.setValue(`${labelDiskSize} Free`);
-      indicatorLabel.setValue(`${selectedNode.getLabel()} ${labelDiskSize} Free`);
+      indicatorLabel.setValue(`${currentNode.getLabel()} ${labelDiskSize} Free`);
     },
 
     // Cleanup method
     destruct: function() {
       const currentNode = this.getCurrentNode();
-      const selectedNode = this.getSelectedNode();
       if (currentNode) {
         this._unsubscribe(currentNode.getNodeId())
-      }
-      if (selectedNode) {
-        this._unsubscribe(selectedNode.getNodeId())
       }
     }
   }

--- a/services/static-webserver/client/source/class/osparc/workbench/DiskUsageIndicator.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/DiskUsageIndicator.js
@@ -166,8 +166,7 @@ qx.Class.define("osparc.workbench.DiskUsageIndicator", {
       });
 
       const indicatorLabel = this.getChildControl("disk-indicator-label");
-      // indicatorLabel.setValue(`${labelDiskSize} Free`);
-      indicatorLabel.setValue(`${currentNode.getLabel()} ${labelDiskSize} Free`);
+      indicatorLabel.setValue(`${labelDiskSize} Free`);
     },
 
     // Cleanup method


### PR DESCRIPTION
## What do these changes do?
- [x] Move indicator form Workbench View to Iframe's button container

Bonus:
- [x] Do not show Import button in Study Browser
- [x] Do not show Sharee Permissions error in S4L


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
